### PR TITLE
Add keysend payment id

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Send a text message to a destination.
 - `34349337`: Message Signature Bytes
 - `34349339`: Message Signer Public Key Bytes
 - `34349343`: Epoch Time In Nanoseconds, Big-Endian Encoded
-- `5482373481`: 32 Byte keysend id to group multiple inccoming payments by it (payee is supposed to provide this id beforehand).
+- `5482373481`: 32 Byte keysend id to group multiple incoming payments by it (payee is supposed to provide this id beforehand).
 - `5482373484`: 32 Byte Preimage Corresponding to HTLC Preimage Hash
 
 ## KeySend-Protocol-3 Ping

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Send a text message to a destination.
 - `34349337`: Message Signature Bytes
 - `34349339`: Message Signer Public Key Bytes
 - `34349343`: Epoch Time In Nanoseconds, Big-Endian Encoded
+- `5482373481`: 32 Byte keysend id to group multiple inccoming payments by it (payee is supposed to provide this id beforehand).
 - `5482373484`: 32 Byte Preimage Corresponding to HTLC Preimage Hash
 
 ## KeySend-Protocol-3 Ping


### PR DESCRIPTION
This will allow payee wallet to group payments coming from different keysend requests together (and display them as a single cumulative record per keysend request, for example: "this keysend request yielded 12 incoming payments and this much total money"). 

Payee is supposed to provide keysend id along with `nodeId` beforehand somehow, perhaps a new type of "keysend invoice" will be useful here. If not provided then can be set to random or not included by payer and it's up to payee wallet how to handle that.